### PR TITLE
Simplification of the compose file and instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Note: Unofficial Discord clients are against Discord's Terms of Service, so use 
 - Docker
 - Docker Compose
 
-### Running the Container
+### Running the containers for the first time
 
 To run the Docker setup, it requires a hands-on approach to get started.
 
@@ -26,55 +26,79 @@ To run the Docker setup, it requires a hands-on approach to get started.
    ```sh
    git clone https://github.com/HotaruBlaze/NSO-RPC-Docker.git
    ```
-2. Navigate to the project directory:
+1. Navigate to the project directory:
    ```sh
    cd NSO-RPC-Docker
    ```
-3. Build the Docker image:
+1. Run:
    ```sh
-   docker build -t ghcr.io/hotarublaze/nso-rpc-docker:latest .
+   docker compose run --rm nso-rpc
    ```
-4. Start the Webcord service:
+   This command will automatically build (if not previously built) the NSO-RPC container and allow you to do the initial setup.
+
+1. Follow the instructions on the prompt. If clicking on the link gives you "The request contains an error," the URL may not have been copied correctly.
+
+1. After setting your user ID, you wont get output back. Type `Ctrl + C` to stop the container.
+
+1. Run
    ```sh
-   docker-compose up -d webcord
+   docker compose up -d
    ```
-5. Open a web browser and go to the server's IP address on port 5000, such as `http://127.0.0.1:5000` or `http://10.0.0.24:5000`.
-6. Log in to Discord. If you have issues with the QR code, log in directly.
-7. Once logged in, go to `File > Settings`, and make the following changes:
-   - Enable Developer Mode
+   to start the containers.
+
+1. Open a web browser and go to `http://localhost:3000` or `http://127.0.0.1:3000` to connect to the WebCord container.
+
+1. Log in to Discord. If you have issues with the QR code, log in directly.
+
+1. Once logged in, go to `File > Settings`, and make the following changes:
    - Untick "Use built-in Content Security Policy"
-8. Restart Webcord via `File > Relaunch`.
-9. Return to your terminal and run the following command:
-   ```sh
-   docker run -it --rm \
-       --name nso-rpc \
-       --network host \
-       -v $PWD/NSO-RPC:/root/Documents/NSO-RPC \
-       -e PUID=1000 \
-       -e PGID=1000 \
-       -e TZ=Etc/UTC \
-       ghcr.io/hotarublaze/nso-rpc-docker:latest
-   ```
-10. Follow the instructions on screen. If clicking on the link gives you "The request contains an error," the URL may not have been copied correctly.
-11. After setting your user ID, you wont get output back, wait a couple of seconds or a minute then you can stop the Docker container via `Ctrl + C`.
-12. Now bring up nso-rpc with WebCord and check the logs for the NSO-RPC service:
-   ```sh
-   docker-compose up -d && docker-compose logs -f nso-rpc
-   ```
-13. You should see something like the following output:
-   ```sh
-nso-rpc    | [arRPC] arRPC v3.1.0
-nso-rpc    | (node:7) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
-nso-rpc    | (Use `node --trace-warnings ...` to show where the warning was created)
-nso-rpc    | [arRPC > bridge] listening on 1337
-nso-rpc    | [arRPC > ipc] listening at /tmp/discord-ipc-0
-nso-rpc    | [arRPC > websocket] 6463 in use!
-nso-rpc    | [arRPC > websocket] listening on 6464
-nso-rpc    | [arRPC > process] started
-nso-rpc    | [arRPC > ipc] new connection!
-   ```
-14. Open Chrome Dev Tools in Webcord by pressing `Ctrl + Shift + I`, and then select console, and type `allow pasting`
-15. Now paste the contents of `webcord-hook.js` into the console. (This script can also be found on arRPC's repo [here](https://github.com/OpenAsar/arrpc/blob/main/examples/bridge_mod.js)).
-16. Return to your console output. You should now see `[arRPC > bridge] web connected`.
+   - Enable Developer Mode
+
+1. Close the settings window.
+
+1. Restart Webcord via `File > Relaunch`.
+
+1. Open Chrome Dev Tools in Webcord by pressing `Ctrl + Shift + I`, and then select console, and type `allow pasting`
+
+1. Now paste the contents of `webcord-hook.js` into the console and press Enter. (This script can also be found on arRPC's repo [here](https://github.com/OpenAsar/arrpc/blob/main/examples/bridge_mod.js)).
+
+   **NOTE**: To be able to paste, you might need to use KasmVNC's Clipboard feature by clicking on the little arrow on the left of the screen, then clicking on "Clipboard" and pasting the `webcord-hook.js` contents inside the text box that shows up, before you're able to paste it on the console.
 
 **You should now be fully setup and should see Switch RPC presence on your account.**
+
+### Subsequent runs
+
+For subsequent runs, you only need to to:
+
+1. Run
+   ```sh
+   docker compose up -d
+   ```
+   to start the containers.
+
+2. Login to Discord as described above.
+
+3. Paste the `webcord-hook.js` into the Chrome Dev Tools console, as described above.
+
+### Troubleshooting
+
+If you're having trouble, run the following to see the NSO-RPC log:
+
+```sh
+docker compose logs nso-rpc
+```
+
+The log of a successful setup should look similar to this:
+
+```sh
+nso-rpc  | [arRPC] arRPC v3.1.0
+nso-rpc  | (node:7) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
+nso-rpc  | (Use `node --trace-warnings ...` to show where the warning was created)
+nso-rpc  | [arRPC > bridge] listening on 1337
+nso-rpc  | [arRPC > ipc] listening at /tmp/discord-ipc-0
+nso-rpc  | [arRPC > websocket] listening on 6463
+nso-rpc  | [arRPC > process] started
+nso-rpc  | [arRPC > ipc] new connection!
+nso-rpc  | Successfully Connected to Discord.
+nso-rpc  | [arRPC > bridge] web connected
+```

--- a/Readme.md
+++ b/Readme.md
@@ -40,13 +40,12 @@ To run the Docker setup, it requires a hands-on approach to get started.
 
 1. After setting your user ID, you wont get output back. Type `Ctrl + C` to stop the container.
 
-1. Run
+1. Run the following to start the containers.
    ```sh
    docker compose up -d
    ```
-   to start the containers.
 
-1. Open a web browser and go to `http://localhost:3000` or `http://127.0.0.1:3000` to connect to the WebCord container.
+1. Open a web browser and go to `http://your_server_hostname:3000` or `http://your_server_ip:3000` to connect to the WebCord container.
 
 1. Log in to Discord. If you have issues with the QR code, log in directly.
 
@@ -58,11 +57,13 @@ To run the Docker setup, it requires a hands-on approach to get started.
 
 1. Restart Webcord via `File > Relaunch`.
 
-1. Open Chrome Dev Tools in Webcord by pressing `Ctrl + Shift + I`, and then select console, and type `allow pasting`
+1. Open Chrome Dev Tools in Webcord by pressing `Ctrl + Shift + I`, and then click on `Console`.
 
 1. Now paste the contents of `webcord-hook.js` into the console and press Enter. (This script can also be found on arRPC's repo [here](https://github.com/OpenAsar/arrpc/blob/main/examples/bridge_mod.js)).
 
-   **NOTE**: To be able to paste, you might need to use KasmVNC's Clipboard feature by clicking on the little arrow on the left of the screen, then clicking on "Clipboard" and pasting the `webcord-hook.js` contents inside the text box that shows up, before you're able to paste it on the console.
+   **NOTE 1**: To be able to paste, you might need to use KasmVNC's Clipboard feature by clicking on the little arrow on the left of the screen, then clicking on "Clipboard" and pasting the `webcord-hook.js` contents inside the text box that shows up, before you're able to paste it on the console.
+
+   **NOTE 2**: The first time you try to paste on Chrome's console, you might need to type `allow pasting` first.
 
 **You should now be fully setup and should see Switch RPC presence on your account.**
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ To run the Docker setup, it requires a hands-on approach to get started.
 
 ### Subsequent runs
 
-For subsequent runs, you only need to to:
+For subsequent runs, you only need to:
 
 1. Run
    ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,30 @@
----
 services:
   webcord:
     image: lscr.io/linuxserver/webcord:latest
     container_name: webcord
-    security_opt:
-      - seccomp:unconfined
     environment:
       - PUID=1000
       - PGID=1000
-      - CUSTOM_PORT=5000
-      - CUSTOM_HTTPS_PORT=5001
       - TZ=Etc/UTC
+    ports:
+      - 3000:3000
+      - 3001:3001
     volumes:
-      - ./Webcord/config:/config
-    network_mode: host
+      - webcord:/config
     shm_size: "1gb"
     restart: unless-stopped
 
   nso-rpc:
     image: ghcr.io/hotarublaze/nso-rpc-docker:latest
+    build: .
     container_name: nso-rpc
-    network_mode: host
+    network_mode: service:webcord
     stdin_open: true
     tty: true
     volumes:
-      - ./NSO-RPC:/root/Documents/NSO-RPC
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Etc/UTC
+      - nso-rpc:/root/Documents/NSO-RPC
     restart: unless-stopped
+
+volumes:
+  nso-rpc:
+  webcord:


### PR DESCRIPTION
This simplifies a few things on the compose file and allows for less steps for the user:

- Builds your NSO-RPC container automatically on first run.
- Makes it work in an isolated network between the containers, so it does not need to touch the host network.
- Ads named volumes for configuration persistence.
- Removes a few things that were not necessary.

I've also simplified the Readme with a new sequence of actions and clarified some points.

Please do tell me if you disagree with anything!

Possible improvements would be:
- Find a way for WebCord to log back in automatically when the container is restarted.
- Find a way to somehow inject the `webcord-hook.js` code into WebCord without the need of user intervention, as this will need to be done every time the service is restarted.
- Have the initial NSO-RPC setup be executed as a separate command after the container is up.